### PR TITLE
Making sure MAC address octets in ARP table have leading zeros.

### DIFF
--- a/lib/arp_table.js
+++ b/lib/arp_table.js
@@ -40,6 +40,23 @@ function parse_arp_table(arpt){
     // Get the Corresponding MAC Addres by splitting 'at'
     var mac = entry.split(' at ')[1];
     mac = mac.split('on')[0].trim();
+
+    // make sure MAC addresses are in lowercase
+    mac = mac.toLowerCase();
+
+    // make sure octets have a leading zero
+    var mac_splited = mac.split(":");
+    for(var i in mac_splited) {
+      if(mac_splited.hasOwnProperty(i)) {
+        if(mac_splited[i].length == 1) {
+          mac_splited[i] = "0" + mac_splited[i];
+        }
+      }
+    }
+
+    // join octets again
+    mac = mac_splited.join(":");
+
     arp_obj['mac'] = mac;
 
     arp_arr.push(arp_obj);


### PR DESCRIPTION
To make sure every octet of a MAC address has two chars I’ve added a leading zero to shorter ones. At least on OS X ARP entries don’t have leading zeros in MAC address octets.
