### PR TITLE
To support linux

### DIFF
--- a/lib/arp_table.js
+++ b/lib/arp_table.js
@@ -37,9 +37,8 @@ function parse_arp_table(arpt){
     var ip = entry.slice(ip_start + 1, ip_end);
     arp_obj['ip'] = ip;
 
-    // Get the Corresponding MAC Addres by splitting 'at'
-    var mac = entry.split(' at ')[1];
-    mac = mac.split('on')[0].trim();
+    // Get the Corresponding MAC Addres by splitting
+    var mac = entry.split(' ')[3];
 
     // make sure MAC addresses are in lowercase
     mac = mac.toLowerCase();


### PR DESCRIPTION
On Linux ARP includes a " [ether]" after the mac address so splitting at " at " means the MAC address look like "xx:..:xx [ether]".  
