### PR TITLE
Handle long output from arp

### DIFF
--- a/lib/arp_table.js
+++ b/lib/arp_table.js
@@ -5,11 +5,11 @@ var spawn = require('child_process').spawn;
 
 function get_arp_table(callback) {
   var arp = spawn('arp', ['-a']);
-  var arp_str = "";
+  var arp_str = [];
 
   arp.stdout.setEncoding('utf8');
   arp.stdout.on('data', function(data) {
-    arp_str = data;
+    arp_str.push(data);
   });
   arp.on('close', function(x) {
     callback(null, parse_arp_table(arp_str));
@@ -20,9 +20,10 @@ function get_arp_table(callback) {
 
 // Parse ARP details from table
 // TODO: Validate and format IP and MAC Addresses
-function parse_arp_table(arpt) {
+function parse_arp_table(arp_str) {
 
   var arp_arr = [];
+  var arpt = arp_str.join();
   arpt = arpt.split('\n');
   var x;
   for (x in arpt) {


### PR DESCRIPTION
If the output from arp is long for example (256 lines), the on 'data' for stdout is called multiple times and the complete arp table is not returned.
