### PR TITLE
Workaround for v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "debug": "^3.1.0",
     "getmac": "1.0.7",
     "ip": "1.0.2",
-    "pcap": "mranney/node_pcap"
+    "pcap": "git+https://github.com/realdennis/node_pcap.git"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For issue #12 ,
I found that if fix the socketwatcher / node_pcap code (namespace deprecated message) like this, node v10 will build pass .
I [pull request](https://github.com/node-pcap/node_pcap/pull/243) to node_pcap, and socketwatcher also had a [fork](https://github.com/bytzdev/node-socketwatcher/commit/d252d3f8c45f565a0a48ebd155d4f9e4666798d9) to solve this issue ,
But, both are not update recently, so I pull request for v10 work around.